### PR TITLE
capitalize component NewTodo

### DIFF
--- a/components/newTodo.jsx
+++ b/components/newTodo.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-const newTodo = ({onChange}) => (
+const NewTodo = ({onChange}) => (
   <div>
     <h3>New</h3>
     <input type="text" onKeyUp={onChange}/>
   </div>
 )
 
-export default newTodo
+export default NewTodo


### PR DESCRIPTION
When you add the NewTodo component in your todo.jsx, you have it as "NewTodo", not "newTodo". This was giving me errors when trying your (excellent) demo.
